### PR TITLE
fix: remove rollup patch

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -966,21 +966,6 @@ in
       };
     };
 
-    # This should not be necessary, as this plugin claims to
-    # respect the `preserveSymlinks` option of rollup.
-    # Adding the NODE_PATH to the module directories fixes it for now.
-    "@rollup/plugin-node-resolve" = {
-      respect-node-path = {
-        postPatch = ''
-          for f in $(find -name '*.js'); do
-            substituteInPlace $f --replace \
-              "moduleDirectories: ['node_modules']," \
-              "moduleDirectories: ['node_modules'].concat(process.env.NODE_PATH.split( /[;:]/ )),"
-          done
-        '';
-      };
-    };
-
     "@sentry/cli" = {
       add-binary = {
         buildScript = ''


### PR DESCRIPTION
Subj, this patch appends NODE_PATH to the `moduleDirectories` which according to [plugin docs][module-directories] would be used to recursively search for modules.

It does, however, cause rollup to fail with an error, complaining about absolute paths belonging in the [`modulePaths`][module-paths]. One way to workaround this issue would be to split `moduleDirectories` configuration across two lines, which would cause search and replace to fail and subsequently rollup would not complain. This workaround leads to working build, which leads me to believe that existing comment is right and this patch is not needed in the first place.

[module-directories]: <https://github.com/rollup/plugins/tree/master/packages/node-resolve#moduledirectories>
[module-paths]: <https://github.com/rollup/plugins/tree/master/packages/node-resolve#modulepaths>